### PR TITLE
Correctly reset nextSendTime after batch.

### DIFF
--- a/cloudwatch_writer.go
+++ b/cloudwatch_writer.go
@@ -166,7 +166,7 @@ func (c *CloudWatchWriter) queueMonitor() {
 			c.sendBatch(batch, 0)
 			batch = nil
 			batchSize = 0
-			nextSendTime.Add(c.getBatchInterval())
+			nextSendTime = time.Now().Add(c.getBatchInterval())
 		}
 
 		item := c.queue.Dequeue()


### PR DESCRIPTION
Currently, we decide when the nextSendTime should be at the start, and
we update it when we exceed the batch size limit or the max num log
events limit.

However, we do not reset it when we send the batch normally.  This
appears to be due to a mistake, as the code does an Add on nextSendTime,
however Add on a time.Time simply returns a new time.Time instead of
modifying the current one.

This results in trying to send roughly every 1ms, which makes AWS fairly
unhappy.